### PR TITLE
Fix CreditResponse (0x8009) decode crashing the connection

### DIFF
--- a/lib/message/buffer.ex
+++ b/lib/message/buffer.ex
@@ -105,7 +105,19 @@ defmodule RabbitMQStream.Message.Buffer do
     frames
     |> Enum.reverse()
     |> Enum.reduce(queue, fn frame, acc ->
-      :queue.in(Decoder.decode(frame), acc)
+      try do
+        :queue.in(Decoder.decode(frame), acc)
+      rescue
+        error ->
+          require Logger
+
+          Logger.warning("RabbitMQStream: dropping undecodable frame",
+            error: inspect(error),
+            frame: inspect(frame, limit: 64)
+          )
+
+          acc
+      end
     end)
   end
 end

--- a/lib/message/decoder.ex
+++ b/lib/message/decoder.ex
@@ -19,6 +19,14 @@ defmodule RabbitMQStream.Message.Decoder do
     |> decode(buffer)
   end
 
+  def decode(%Response{command: :credit} = response, buffer) do
+    <<code::unsigned-integer-size(16), _subscription_id::unsigned-integer-size(8)>> = buffer
+
+    response = %{response | code: decode_code(code)}
+
+    %{response | data: Data.decode(response, "")}
+  end
+
   def decode(%Response{command: command} = response, buffer)
       when command in [
              :close,
@@ -28,7 +36,6 @@ defmodule RabbitMQStream.Message.Decoder do
              :delete_producer,
              :subscribe,
              :unsubscribe,
-             :credit,
              :query_offset,
              :query_producer_sequence,
              :peer_properties,

--- a/test/message/decoder_test.exs
+++ b/test/message/decoder_test.exs
@@ -1,0 +1,18 @@
+defmodule RabbitMQStream.Message.DecoderTest do
+  use ExUnit.Case, async: true
+
+  alias RabbitMQStream.Message.{Decoder, Response}
+  alias RabbitMQStream.Message.Types
+
+  # Exact prod CreditResponse frame (minus the 4-byte length prefix):
+  # key 0x8009, version 1, response_code 0x11 (precondition_failed), subscription_id 7.
+  @credit_response <<0x8009::16, 1::16, 0x11::16, 7::8>>
+
+  test "decodes a CreditResponse as a non-correlated response without crashing" do
+    result = Decoder.decode(@credit_response)
+
+    assert %Response{command: :credit, code: :precondition_failed} = result
+    assert result.correlation_id == nil
+    assert result.data == %Types.CreditResponseData{}
+  end
+end

--- a/test/message/decoder_test.exs
+++ b/test/message/decoder_test.exs
@@ -15,4 +15,19 @@ defmodule RabbitMQStream.Message.DecoderTest do
     assert result.correlation_id == nil
     assert result.data == %Types.CreditResponseData{}
   end
+
+  test "parse_frames drops an undecodable frame and keeps valid ones" do
+    alias RabbitMQStream.Message.Buffer
+
+    # 0x00FF is not a known command -> Decoder.decode raises. It must be skipped.
+    bad = <<0x00FF::16, 1::16, 0x00>>
+    good = @credit_response
+
+    # Buffer stores frames reversed (prepended); pass [good, bad] so processing
+    # order is bad then good.
+    queue = Buffer.parse_frames([good, bad], :queue.new())
+    commands = :queue.to_list(queue)
+
+    assert [%Response{command: :credit}] = commands
+  end
 end


### PR DESCRIPTION
## Problem

`RabbitMQStream.Message.Decoder` lists `:credit` among the **correlated** responses, so it decodes a `CreditResponse` by reading `correlation_id::32, code::16` (6 bytes). But a `CreditResponse` has **no** correlation id — its body is `response_code::16, subscription_id::8` (3 bytes). Decoding one therefore raises `MatchError`, and because `Buffer.parse_frames/2` calls `Decoder.decode/1` directly inside the connection `GenServer`'s `handle_info` with no rescue, that single frame crashes the whole connection.

The broker sends a `CreditResponse` only on error — e.g. crediting a subscription it no longer knows about — which happens routinely during single-active-consumer rebalancing and after a reconnect. In production this crash-looped a consumer under load (each reconnect re-hit the frame).

## Protocol references

Per the RabbitMQ streams protocol spec — [`deps/rabbitmq_stream/docs/PROTOCOL.adoc`](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_stream/docs/PROTOCOL.adoc):

`Credit` is not a correlated command — the request carries a `SubscriptionId`, not a `CorrelationId`:

```
Credit => Key Version SubscriptionId Credit
  Key => uint16 // 0x0009
  Version => uint16
  SubscriptionId => uint8
  Credit => uint16 // the number of chunks that can be sent
```

And the response has no `CorrelationId` — only a response code and subscription id:

```
CreditResponse => Key Version ResponseCode SubscriptionId
  Key => uint16 // 0x8009
  Version => uint16
  ResponseCode => uint16
  SubscriptionId => uint8
```

The spec also notes the response is an error-only signal:

> NB: the server sent a response only in case of problem, e.g. crediting an unknown subscription.

A real frame seen in production was `<<0,0,0,7, 0x80,0x09, 0,1, 0x00,0x11, 0x07>>` — length 7, key `0x8009`, version 1, `ResponseCode = 0x0011` (`precondition_failed`), `SubscriptionId = 7`. The correlated-response clause tried to read a 4-byte correlation id from the 3-byte body → `MatchError`.

## Fix

1. **Correctness** — a dedicated `:credit` `decode/2` clause reads `code::16, subscription_id::8` (no correlation id) and returns the existing `%Types.CreditResponseData{}`; `:credit` is removed from the correlated-response clause's command list.
2. **Resilience (defense in depth)** — `Buffer.parse_frames/2` wraps the per-frame `Decoder.decode/1` in `try/rescue`: an undecodable frame is logged (`Logger.warning`) and skipped instead of crashing the connection process. This keeps a single malformed/unexpected frame from taking down the whole connection.

## Tests

Adds an offline `test/message/decoder_test.exs` (no broker required):

1. The production `CreditResponse` bytes decode to `%Response{command: :credit, code: :precondition_failed}` with `correlation_id: nil` and `data: %Types.CreditResponseData{}`.
2. `parse_frames/2` drops an unknown/undecodable frame while a valid frame in the same batch still decodes.

The existing broker-tagged integration tests are unaffected.