### PR TITLE
fix: eliminate race in persistent consumer test

### DIFF
--- a/test/consumer_test.exs
+++ b/test/consumer_test.exs
@@ -126,6 +126,13 @@ defmodule RabbitMQStreamTest.Consumer do
         offset_tracking: [count: [store_after: 1]]
       )
 
+    # start_link/1 returns as soon as init/1 does, before the subscribe request
+    # (sent from handle_continue/2) is acknowledged by the broker. Since GenServer
+    # guarantees handle_continue completes before any queued call is answered, this
+    # call blocks until the subscription is active, avoiding a race with `publish`
+    # below when `initial_offset: :next` is used.
+    Consumer.get_credits()
+
     message1 = %{"message" => "Consumer Test: 1"}
     message2 = %{"message" => "Consumer Test: 2"}
     message3 = %{"message" => "Consumer Test: 3"}


### PR DESCRIPTION
Consumer.start_link/1 returns as soon as init/1 does, before the subscribe request (sent from handle_continue/2) reaches the broker. With initial_offset: :next, publishing right after start_link could race the subscribe, causing the broker to miss the first message and the test to fail intermittently.

GenServer guarantees handle_continue completes before any queued call is answered, so calling Consumer.get_credits() right after start_link blocks until the subscription is actually active, without resorting to a sleep.