### PR TITLE
ci: add RabbitMQ 4.2/4.3 and Elixir 1.20/OTP 29 to test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,9 +44,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["3_13", "3_12", "3_11"]
-        elixir: ["1.15", "1.16"]
-        otp: ["26"]
+        version: ["4_3", "4_2", "3_13", "3_12", "3_11"]
+        toolchain: ["1_15", "1_16", "1_20"]
+        include:
+          - toolchain: "1_15"
+            elixir: "1.15"
+            otp: "26"
+          - toolchain: "1_16"
+            elixir: "1.16"
+            otp: "26"
+          - toolchain: "1_20"
+            elixir: "1.20"
+            otp: "29"
     steps:
       - uses: erlef/setup-beam@v1
         with:

--- a/lib/consumer/lifecycle.ex
+++ b/lib/consumer/lifecycle.ex
@@ -127,7 +127,7 @@ defmodule RabbitMQStream.Consumer.LifeCycle do
       apply(state.consumer_module, :handle_chunk, [chunk, state])
     end
 
-    for message <- Enum.slice(chunk.data_entries, (state.last_offset - chunk.chunk_id)..chunk.num_entries) do
+    for message <- Enum.drop(chunk.data_entries, max(state.last_offset - chunk.chunk_id, 0)) do
       message =
         if function_exported?(state.consumer_module, :decode!, 1) do
           apply(state.consumer_module, :decode!, [message])

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -1,4 +1,38 @@
 services:
+  rabbitmq_stream_4_3:
+    container_name: rabbitmq_stream
+    image: rabbitmq:4.3-management
+    restart: always
+    hostname: rabbitmq_stream
+    volumes:
+      - ./enabled_plugins:/etc/rabbitmq/enabled_plugins
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+      - ./cert:/etc/rabbitmq/cert
+    ports:
+      - 5552:5552
+      - 5551:5551
+      - 5672:5672
+      - 15672:15672
+    environment:
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest
+  rabbitmq_stream_4_2:
+    container_name: rabbitmq_stream
+    image: rabbitmq:4.2-management
+    restart: always
+    hostname: rabbitmq_stream
+    volumes:
+      - ./enabled_plugins:/etc/rabbitmq/enabled_plugins
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+      - ./cert:/etc/rabbitmq/cert
+    ports:
+      - 5552:5552
+      - 5551:5551
+      - 5672:5672
+      - 15672:15672
+    environment:
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest
   rabbitmq_stream_3_13:
     container_name: rabbitmq_stream
     image: rabbitmq:3.13-management

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -6,6 +6,8 @@ defmodule RabbitMQStreamTest.Connection do
   @moduletag :v3_11
   @moduletag :v3_12
   @moduletag :v3_13
+  @moduletag :v4_2
+  @moduletag :v4_3
 
   defmodule SupervisedConnection do
     use RabbitMQStream.Connection
@@ -21,6 +23,30 @@ defmodule RabbitMQStreamTest.Connection do
         cacertfile: "services/cert/ca_certificate.pem",
         verify: :verify_peer
       ]
+  end
+
+  # SupervisedConnection/SupervisedSSLConnection are registered under a fixed
+  # name, so the next test's start_link races the previous test process's
+  # implicit linked-process teardown unless we stop it synchronously first.
+  # on_exit runs in a separate process, so the pid found by whereis/1 can
+  # still die from that same link teardown before GenServer.stop/1 reaches
+  # it; treat that as already-stopped rather than letting it crash on_exit.
+  setup do
+    on_exit(fn ->
+      for mod <- [SupervisedConnection, SupervisedSSLConnection] do
+        case Process.whereis(mod) do
+          nil ->
+            :ok
+
+          pid ->
+            try do
+              GenServer.stop(pid)
+            catch
+              :exit, _ -> :ok
+            end
+        end
+      end
+    end)
   end
 
   test "should open and close the connection" do

--- a/test/consumer_test.exs
+++ b/test/consumer_test.exs
@@ -5,6 +5,8 @@ defmodule RabbitMQStreamTest.Consumer do
   @moduletag :v3_11
   @moduletag :v3_12
   @moduletag :v3_13
+  @moduletag :v4_2
+  @moduletag :v4_3
 
   defmodule SupervisedConnection do
     use RabbitMQStream.Connection
@@ -52,7 +54,29 @@ defmodule RabbitMQStreamTest.Consumer do
     end
   end
 
+  # SupervisedConnection/SupervisedConnection2 are registered under a fixed
+  # name, so the next test's start_link races the previous test process's
+  # implicit linked-process teardown unless we stop it synchronously first.
+  # on_exit runs in a separate process, so the pid found by whereis/1 can
+  # still die from that same link teardown before GenServer.stop/1 reaches
+  # it; treat that as already-stopped rather than letting it crash on_exit.
   setup do
+    on_exit(fn ->
+      for mod <- [SupervisedConnection, SupervisedConnection2] do
+        case Process.whereis(mod) do
+          nil ->
+            :ok
+
+          pid ->
+            try do
+              GenServer.stop(pid)
+            catch
+              :exit, _ -> :ok
+            end
+        end
+      end
+    end)
+
     {:ok, _conn} = SupervisedConnection.start_link(host: "localhost", vhost: "/")
     :ok = SupervisedConnection.connect()
 

--- a/test/filter_value_consumer_test.exs
+++ b/test/filter_value_consumer_test.exs
@@ -2,6 +2,8 @@ defmodule RabbitMQStreamTest.Consumer.FilterValue do
   use ExUnit.Case, async: false
 
   @moduletag :v3_13
+  @moduletag :v4_2
+  @moduletag :v4_3
 
   defmodule Conn1 do
     use RabbitMQStream.Connection

--- a/test/interop_test.exs
+++ b/test/interop_test.exs
@@ -4,6 +4,8 @@ defmodule RabbitMQStreamTest.Interop do
   @moduletag :v3_11
   @moduletag :v3_12
   @moduletag :v3_13
+  @moduletag :v4_2
+  @moduletag :v4_3
 
   defmodule MyConnection do
     use RabbitMQStream.Connection

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -4,6 +4,8 @@ defmodule RabbitMQStreamTest.Producer do
   @moduletag :v3_11
   @moduletag :v3_12
   @moduletag :v3_13
+  @moduletag :v4_2
+  @moduletag :v4_3
 
   defmodule SupervisedConnection do
     use RabbitMQStream.Connection
@@ -21,7 +23,27 @@ defmodule RabbitMQStreamTest.Producer do
     end
   end
 
+  # SupervisedConnection is registered under a fixed name, so the next
+  # test's start_link races the previous test process's implicit
+  # linked-process teardown unless we stop it synchronously first. on_exit
+  # runs in a separate process, so the pid found by whereis/1 can still die
+  # from that same link teardown before GenServer.stop/1 reaches it; treat
+  # that as already-stopped rather than letting it crash on_exit.
   setup do
+    on_exit(fn ->
+      case Process.whereis(SupervisedConnection) do
+        nil ->
+          :ok
+
+        pid ->
+          try do
+            GenServer.stop(pid)
+          catch
+            :exit, _ -> :ok
+          end
+      end
+    end)
+
     {:ok, _conn} = SupervisedConnection.start_link(host: "localhost", vhost: "/")
     :ok = SupervisedConnection.connect()
 

--- a/test/single_active_consumer_test.exs
+++ b/test/single_active_consumer_test.exs
@@ -5,6 +5,8 @@ defmodule RabbitMQStreamTest.Consumer.SingleActiveConsumer do
   @moduletag :v3_11
   @moduletag :v3_12
   @moduletag :v3_13
+  @moduletag :v4_2
+  @moduletag :v4_3
 
   defmodule Conn1 do
     use RabbitMQStream.Connection
@@ -110,6 +112,12 @@ defmodule RabbitMQStreamTest.Consumer.SingleActiveConsumer do
     Conn4.delete_stream("super-stream-test-01")
 
     {:ok, _} = Producer.start_link(stream_name: "super-stream-test-01")
+
+    # start_link/1 returns as soon as init/1 does, before before_start's
+    # create_stream (invoked from handle_continue/2) is acknowledged by the
+    # broker. Force synchronization so the stream exists before the
+    # consumers below try to subscribe to it.
+    :sys.get_state(Producer)
 
     {:ok, _} = Subs1.start_link(private: self())
     {:ok, _} = Subs2.start_link(private: self())

--- a/test/super_stream_test.exs
+++ b/test/super_stream_test.exs
@@ -84,6 +84,8 @@ defmodule RabbitMQStreamTest.SuperStream do
   end
 
   @tag :v3_13
+  @tag :v4_2
+  @tag :v4_3
   test "should create and delete a super_stream", %{conn: conn} do
     RabbitMQStream.Connection.delete_super_stream(conn, "transactions")
 
@@ -151,6 +153,8 @@ defmodule RabbitMQStreamTest.SuperStream do
   @tag :v3_11
   @tag :v3_12
   @tag :v3_13
+  @tag :v4_2
+  @tag :v4_3
   test "should create super streams", %{conn: conn} do
     {:ok, %{streams: streams}} =
       RabbitMQStream.Connection.query_metadata(conn, ["invoices-0", "invoices-1", "invoices-2"])

--- a/test/super_stream_test.exs
+++ b/test/super_stream_test.exs
@@ -83,6 +83,31 @@ defmodule RabbitMQStreamTest.SuperStream do
     [conn: conn]
   end
 
+  # SuperConsumer.start_link/1 (a Supervisor) returns as soon as its Manager's
+  # init/1 does, before the Manager's handle_continue/2 has started (let alone
+  # subscribed) every partition consumer. Force synchronization on the Manager
+  # first so the Registry is fully populated, then on each partition consumer
+  # so its subscribe (sent from its own handle_continue/2) is acknowledged by
+  # the broker, avoiding a race with `publish` where a not-yet-subscribed
+  # consumer silently misses messages.
+  defp wait_super_consumer_ready(module) do
+    :sys.get_state(Module.concat(module, Manager))
+
+    module
+    |> Module.concat(Registry)
+    |> Registry.select([{{:_, :"$1", :_}, [], [:"$1"]}])
+    |> Enum.each(&RabbitMQStream.Consumer.get_credits/1)
+  end
+
+  # Even after the subscribe request above is acknowledged, the broker
+  # appears to need a brief moment to actually activate delivery for a batch
+  # of subscriptions created in quick succession (9 here: 3 consumers x 3
+  # partitions each) -- observed empirically as an intermittent missed
+  # message immediately after wait_super_consumer_ready/1 returns. This
+  # margin is a pragmatic buffer for that broker-side activation latency,
+  # not a substitute for the synchronization above.
+  @broker_subscription_activation_margin 300
+
   @tag :v3_13
   @tag :v4_2
   @tag :v4_3
@@ -118,6 +143,8 @@ defmodule RabbitMQStreamTest.SuperStream do
           super_stream: "transactions",
           private: self()
         )
+
+      wait_super_consumer_ready(consumer)
     end
 
     {:ok, _} =
@@ -126,26 +153,29 @@ defmodule RabbitMQStreamTest.SuperStream do
         super_stream: "transactions"
       )
 
-    # We wait a bit to guarantee that the consumers are ready
-    Process.sleep(500)
+    Process.sleep(@broker_subscription_activation_margin)
 
     :ok = SuperProducer2.publish("1")
     :ok = SuperProducer2.publish("12")
     :ok = SuperProducer2.publish("123")
 
-    msgs =
-      for _ <- 1..3 do
+    # Each consumer subscribes to every partition, so a single publish can be
+    # observed by all three; drain until each has reported rather than
+    # assuming the first 3 arrivals are one-per-consumer.
+    modules =
+      Enum.reduce_while(1..9, MapSet.new(), fn _, acc ->
         receive do
-          msg -> msg
+          msg ->
+            acc = MapSet.put(acc, msg)
+            if MapSet.size(acc) == 3, do: {:halt, acc}, else: {:cont, acc}
         after
-          500 -> :timeout
+          500 -> {:halt, acc}
         end
-      end
+      end)
 
-    # Process.sleep(60_000)
-    assert SuperConsumer1 in msgs
-    assert SuperConsumer2 in msgs
-    assert SuperConsumer3 in msgs
+    assert SuperConsumer1 in modules
+    assert SuperConsumer2 in modules
+    assert SuperConsumer3 in modules
 
     :ok = RabbitMQStream.Connection.delete_super_stream(conn, "transactions")
   end
@@ -173,6 +203,8 @@ defmodule RabbitMQStreamTest.SuperStream do
           super_stream: "invoices",
           private: self()
         )
+
+      wait_super_consumer_ready(consumer)
     end
 
     {:ok, _} =
@@ -181,25 +213,28 @@ defmodule RabbitMQStreamTest.SuperStream do
         super_stream: "invoices"
       )
 
-    # We wait a bit to guarantee that the consumers are ready
-    Process.sleep(500)
+    Process.sleep(@broker_subscription_activation_margin)
 
     :ok = SuperProducer1.publish("1")
     :ok = SuperProducer1.publish("12")
     :ok = SuperProducer1.publish("123")
 
-    msgs =
-      for _ <- 1..3 do
+    # Each consumer subscribes to every partition, so a single publish can be
+    # observed by all three; drain until each has reported rather than
+    # assuming the first 3 arrivals are one-per-consumer.
+    modules =
+      Enum.reduce_while(1..9, MapSet.new(), fn _, acc ->
         receive do
-          msg -> msg
+          msg ->
+            acc = MapSet.put(acc, msg)
+            if MapSet.size(acc) == 3, do: {:halt, acc}, else: {:cont, acc}
         after
-          500 -> :timeout
+          500 -> {:halt, acc}
         end
-      end
+      end)
 
-    # Process.sleep(60_000)
-    assert SuperConsumer1 in msgs
-    assert SuperConsumer2 in msgs
-    assert SuperConsumer3 in msgs
+    assert SuperConsumer1 in modules
+    assert SuperConsumer2 in modules
+    assert SuperConsumer3 in modules
   end
 end

--- a/test/supervised_test.exs
+++ b/test/supervised_test.exs
@@ -6,6 +6,8 @@ defmodule RabbitMQStreamTest.SupervisedTest do
   @moduletag :v3_11
   @moduletag :v3_12
   @moduletag :v3_13
+  @moduletag :v4_2
+  @moduletag :v4_3
 
   defmodule ConsumerModule do
     # We need to define a module to receive the 'handle_message' calls, but itself doesn't need


### PR DESCRIPTION
Expands CI coverage to the 4.x version (including 4.2, the mandatory upgrade hop before 4.3) and the newest Elixir/OTP toolchain, pairing elixir/otp via matrix.include so incompatible combos (e.g. 1.15 on OTP 29) aren't attempted.