### PR TITLE
test: assert real cluster auto-discovery behavior in clustered_test.exs

### DIFF
--- a/test/clustered_test.exs
+++ b/test/clustered_test.exs
@@ -15,14 +15,29 @@ defmodule RabbitMQStreamTest.Clustered do
     assert :ok = RabbitMQStream.Connection.connect(conn2)
     assert :ok = RabbitMQStream.Connection.connect(conn3)
 
-    RabbitMQStream.Connection.create_stream(conn1, "stream1")
-    RabbitMQStream.Connection.create_stream(conn2, "stream2")
-    RabbitMQStream.Connection.create_stream(conn3, "stream3")
+    assert :ok = RabbitMQStream.Connection.create_stream(conn1, "stream1")
+    assert :ok = RabbitMQStream.Connection.create_stream(conn2, "stream2")
+    assert :ok = RabbitMQStream.Connection.create_stream(conn3, "stream3")
 
-    dbg(RabbitMQStream.Connection.query_metadata(conn1, ["stream1", "stream2", "stream3"]))
+    {:ok, %{streams: streams, brokers: brokers}} =
+      RabbitMQStream.Connection.query_metadata(conn1, ["stream1", "stream2", "stream3"])
 
-    dbg(:sys.get_state(conn1))
-    dbg(:sys.get_state(conn2))
-    dbg(:sys.get_state(conn3))
+    assert Enum.all?(streams, &(&1.code == :ok))
+
+    # conn1 only ever talks to rabbitmq1 directly; seeing all 3 broker
+    # entries proves cluster-wide topology was actually discovered, not
+    # just the local node's view.
+    assert brokers |> Enum.map(& &1.host) |> Enum.sort() == ["rabbitmq1", "rabbitmq2", "rabbitmq3"]
+
+    brokers_by_ref = Map.new(brokers, &{&1.reference, &1.host})
+    leader_host = fn stream_name -> brokers_by_ref[Enum.find(streams, &(&1.name == stream_name)).leader] end
+
+    assert leader_host.("stream1") == "rabbitmq1"
+    assert leader_host.("stream2") == "rabbitmq2"
+    assert leader_host.("stream3") == "rabbitmq3"
+
+    :ok = RabbitMQStream.Connection.delete_stream(conn1, "stream1")
+    :ok = RabbitMQStream.Connection.delete_stream(conn2, "stream2")
+    :ok = RabbitMQStream.Connection.delete_stream(conn3, "stream3")
   end
 end


### PR DESCRIPTION
"should auto discover and connect to all nodes" had no assertions on the parts that mattered -- create_stream's result was discarded, and query_metadata's response was only ever passed to dbg/1. A broker or discovery bug here could pass silently.

Now asserts: each stream is actually created, a connection that only ever talks to rabbitmq1 directly still discovers all 3 broker nodes via query_metadata (proving cluster-wide topology resolution, not just the local node's view), and each stream's reported leader matches the node it was created on. Verified passing against live 3.13, 4.2, and 4.3 clusters (services/cluster/docker-compose.yaml, one broker version at a time).