### PR TITLE
feat: allow overriding RabbitMQ version in cluster docker-compose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,9 @@ To run the Clustered test, run:
     # or for proxied
     docker compose --project-directory services/proxied-cluster up -d
 
+    # Override the RabbitMQ version (defaults to 3.13)
+    RABBITMQ_VERSION=4.3 docker compose --project-directory services/cluster up -d
+
     # Run the tests
     mix test --exclude test --include v3_13_proxied_cluster
 

--- a/services/cluster/docker-compose.yaml
+++ b/services/cluster/docker-compose.yaml
@@ -2,7 +2,7 @@
 # Same as 'services/proxied-cluster/docker-compose.yaml' but without the load balancer.
 services:
   rabbitmq1:
-    image: rabbitmq:3.13-management
+    image: rabbitmq:${RABBITMQ_VERSION:-3.13}-management
     hostname: rabbitmq1
     environment:
       - RABBITMQ_DEFAULT_USER=guest
@@ -19,7 +19,7 @@ services:
       - rabbitmq
 
   rabbitmq2:
-    image: rabbitmq:3.13-management
+    image: rabbitmq:${RABBITMQ_VERSION:-3.13}-management
     hostname: rabbitmq2
     depends_on:
       - rabbitmq1
@@ -36,7 +36,7 @@ services:
       - rabbitmq
 
   rabbitmq3:
-    image: rabbitmq:3.13-management
+    image: rabbitmq:${RABBITMQ_VERSION:-3.13}-management
     hostname: rabbitmq3
     depends_on:
       - rabbitmq1


### PR DESCRIPTION
Parameterize the image tag with RABBITMQ_VERSION (defaults to 3.13) so the cluster compose file can be tested against other broker versions.