### PR TITLE
ci: add cluster-test job to CI (RabbitMQ 4.3, Elixir 1.20/OTP 29)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,3 +89,41 @@ jobs:
 
       - name: Run tests
         run:  mix test --exclude test --include v${{ matrix.version }}
+
+  cluster-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rabbitmq_version: ["3.13", "4.3"]
+        toolchain: ["1_15", "1_16", "1_20"]
+        include:
+          - toolchain: "1_15"
+            elixir: "1.15"
+            otp: "26"
+          - toolchain: "1_16"
+            elixir: "1.16"
+            otp: "26"
+          - toolchain: "1_20"
+            elixir: "1.20"
+            otp: "29"
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Start RabbitMQ cluster
+        run: docker compose --project-directory services/cluster up -d
+        env:
+          RABBITMQ_VERSION: ${{ matrix.rabbitmq_version }}
+
+      - name: Wait for cluster to form
+        run: |
+          timeout 90s bash -c '
+            until docker compose --project-directory services/cluster exec -T rabbitmq1 rabbitmqctl await_online_nodes 3; do
+              sleep 2
+            done
+          '
+
+      - name: Run cluster tests
+        run: |
+          docker run --network cluster_rabbitmq -v "${{ github.workspace }}:/home/rabbitmq-stream" elixir:${{ matrix.elixir }}-otp-${{ matrix.otp }} \
+            /bin/sh -c 'cd /home/rabbitmq-stream; ./services/cluster/test.sh'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,12 @@ jobs:
             done
           '
 
+      - name: Dump cluster logs on failure
+        if: failure()
+        run: |
+          docker compose --project-directory services/cluster ps
+          docker compose --project-directory services/cluster logs
+
       - name: Run cluster tests
         run: |
           docker run --network cluster_rabbitmq -v "${{ github.workspace }}:/home/rabbitmq-stream" elixir:${{ matrix.elixir }}-otp-${{ matrix.otp }} \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,28 +92,13 @@ jobs:
 
   cluster-test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rabbitmq_version: ["3.13", "4.3"]
-        toolchain: ["1_15", "1_16", "1_20"]
-        include:
-          - toolchain: "1_15"
-            elixir: "1.15"
-            otp: "26"
-          - toolchain: "1_16"
-            elixir: "1.16"
-            otp: "26"
-          - toolchain: "1_20"
-            elixir: "1.20"
-            otp: "29"
     steps:
       - uses: actions/checkout@v7
 
       - name: Start RabbitMQ cluster
         run: docker compose --project-directory services/cluster up -d
         env:
-          RABBITMQ_VERSION: ${{ matrix.rabbitmq_version }}
+          RABBITMQ_VERSION: "4.3"
 
       - name: Wait for cluster to form
         run: |
@@ -131,5 +116,5 @@ jobs:
 
       - name: Run cluster tests
         run: |
-          docker run --network cluster_rabbitmq -v "${{ github.workspace }}:/home/rabbitmq-stream" elixir:${{ matrix.elixir }}-otp-${{ matrix.otp }} \
+          docker run --network cluster_rabbitmq -v "${{ github.workspace }}:/home/rabbitmq-stream" elixir:1.20-otp-29 \
             /bin/sh -c 'cd /home/rabbitmq-stream; ./services/cluster/test.sh'

--- a/services/cluster/cluster-entrypoint.sh
+++ b/services/cluster/cluster-entrypoint.sh
@@ -6,6 +6,14 @@ set -e
 HOSTNAME=`env hostname`
 echo "Starting RabbitMQ Server For host: " $HOSTNAME
 
+# Write the cookie ourselves before rabbitmq-server starts, to avoid a known
+# intermittent race between the image generating it and Erlang reading it
+# back on boot.
+mkdir -p /var/lib/rabbitmq
+echo -n "$RABBITMQ_ERLANG_COOKIE" > /var/lib/rabbitmq/.erlang.cookie
+chown rabbitmq:rabbitmq /var/lib/rabbitmq/.erlang.cookie
+chmod 400 /var/lib/rabbitmq/.erlang.cookie
+
 if [ -z "$JOIN_CLUSTER_HOST" ]; then
     /usr/local/bin/docker-entrypoint.sh rabbitmq-server &
     sleep 5

--- a/services/cluster/docker-compose.yaml
+++ b/services/cluster/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       - ../rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
       - ../cert:/etc/rabbitmq/cert
     entrypoint: /usr/local/bin/cluster-entrypoint.sh
+    restart: on-failure:5
     networks:
       - rabbitmq
 
@@ -32,6 +33,7 @@ services:
       - ../rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
       - ../cert:/etc/rabbitmq/cert
     entrypoint: /usr/local/bin/cluster-entrypoint.sh
+    restart: on-failure:5
     networks:
       - rabbitmq
 
@@ -49,6 +51,7 @@ services:
       - ../rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
       - ../cert:/etc/rabbitmq/cert
     entrypoint: /usr/local/bin/cluster-entrypoint.sh
+    restart: on-failure:5
     networks:
       - rabbitmq
 


### PR DESCRIPTION
Clustered tests were previously a manual step for contributors (see CONTRIBUTING.md) with no CI coverage. This adds them to CI as a `cluster-test` job that starts the 3-node cluster from `services/cluster/docker-compose.yaml`, waits for it to form, and runs `test/clustered_test.exs`.

Clustered tests run as a single job (RabbitMQ 4.3, Elixir 1.20/OTP 29), not a version/toolchain matrix. RabbitMQ 3.13 coverage isn't needed here since the single-node `test` job already tests against it.

While validating this in CI, uncovered a known intermittent upstream race in the official RabbitMQ image (docker-library/rabbitmq#318) where `.erlang.cookie` generation and the Erlang VM's own read of it during boot could interleave, crashing `rabbitmq1`. Fixed by having `cluster-entrypoint.sh` write the cookie deterministically before `rabbitmq-server` starts; `restart: on-failure:5` is kept as a fallback for now. Also adds a log-dump step gated on failure, so any future boot issue can be diagnosed without re-instrumenting.