### PR TITLE
fix: eliminate subscribe race in filter-value consumer test

### DIFF
--- a/test/filter_value_consumer_test.exs
+++ b/test/filter_value_consumer_test.exs
@@ -97,6 +97,16 @@ defmodule RabbitMQStreamTest.Consumer.FilterValue do
     {:ok, _} = Subs2.start_link(private: self())
     {:ok, _} = Subs3.start_link(private: self())
 
+    # start_link/1 returns as soon as init/1 does, before the subscribe request (sent
+    # from handle_continue/2) is acknowledged by the broker. Since GenServer guarantees
+    # handle_continue completes before any queued call is answered, these calls block
+    # until each subscription is active, avoiding a race with `publish` below (with
+    # `initial_offset: :next`, anything published before a subscription is active is
+    # simply never delivered to it).
+    Subs1.get_credits()
+    Subs2.get_credits()
+    Subs3.get_credits()
+
     message1 = %{"key" => "Subs1", "value" => "1"}
     message2 = %{"key" => "Subs2", "value" => "2"}
     message3 = %{"value" => "4"}


### PR DESCRIPTION
Subs1/2/3.start_link/1 return as soon as init/1 does, before the subscribe request (sent from handle_continue/2) is acknowledged by the broker. With initial_offset: :next, a message published before a subscription is active is never delivered to it at all, not queued - so publishing immediately after all three start_link calls can race ahead of one of them.

Fixed with the same get_credits() synchronization already used in consumer_test.exs and single_active_consumer_test.exs, relying on GenServer's guarantee that handle_continue completes before any queued call is answered.

This is a distinct failure from the previously-fixed chunk-slicing bug (03a1f62) - that one showed a wrong message present in the mailbox; this one shows a completely empty mailbox, varying which consumer's message goes missing. Reproduced via `mix test --exclude test --include v4_3 --max-cases 8`, looped (~10% failure rate). Validated with 40 consecutive full-suite runs against v4_3 and 15 against v3_13 post-fix, all clean.